### PR TITLE
iOS 10 fixes

### DIFF
--- a/ACKImagePicker/ViewControllers/ACKImagePicker.swift
+++ b/ACKImagePicker/ViewControllers/ACKImagePicker.swift
@@ -28,6 +28,7 @@ open class ACKImagePicker: UINavigationController {
     convenience init() {
         let rootController = ImagePickerViewController()
         self.init(rootViewController: rootController)
+        navigationBar.isTranslucent = false
         self.rootController = rootController
     }
 

--- a/ACKImagePicker/ViewControllers/ACKImagePicker.swift
+++ b/ACKImagePicker/ViewControllers/ACKImagePicker.swift
@@ -28,7 +28,16 @@ open class ACKImagePicker: UINavigationController {
     convenience init() {
         let rootController = ImagePickerViewController()
         self.init(rootViewController: rootController)
-        navigationBar.isTranslucent = false
+        
+        // on iOS 10 we have trouble with `UINavigationBar` covering list of photos
+        // and this is the simplest solution
+        // https://user-images.githubusercontent.com/3148214/87172417-80530080-c2d4-11ea-82bb-914f0f8419ce.png
+        if #available(iOS 11, *) {
+            navigationBar.isTranslucent = true
+        } else {
+            navigationBar.isTranslucent = false
+        }
+        
         self.rootController = rootController
     }
 

--- a/ACKImagePicker/ViewControllers/ImagePickerViewController.swift
+++ b/ACKImagePicker/ViewControllers/ImagePickerViewController.swift
@@ -408,7 +408,7 @@ extension ImagePickerViewController: ACKImagePickerDelegate {
         if #available(iOS 11.0, *) {
             progressView.topAnchor.constraint(equalTo: currentViewController.view.safeAreaLayoutGuide.topAnchor).isActive = true
         } else {
-            progressView.topAnchor.constraint(equalTo: topLayoutGuide.bottomAnchor).isActive = true
+            progressView.topAnchor.constraint(equalTo: currentViewController.topLayoutGuide.bottomAnchor).isActive = true
         }
         
         return (progressView: progressView, overlayView: overlayView)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 ## Next
 
+## Fixed
+- fix crash on iOS 10 ([#12](https://github.com/AckeeCZ/ACKImagePicker/pull/10)) by @olejnjak
+- fix inset on iOS 10 ([#12](https://github.com/AckeeCZ/ACKImagePicker/pull/10)) by @olejnjak
+
 ## 0.2.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 ## Next
 
 ## Fixed
-- fix crash on iOS 10 ([#12](https://github.com/AckeeCZ/ACKImagePicker/pull/10)) by @olejnjak
-- fix inset on iOS 10 ([#12](https://github.com/AckeeCZ/ACKImagePicker/pull/10)) by @olejnjak
+- fix crash on iOS 10 ([#12](https://github.com/AckeeCZ/ACKImagePicker/pull/12)) by @olejnjak
+- fix inset on iOS 10 ([#12](https://github.com/AckeeCZ/ACKImagePicker/pull/12)) by @olejnjak
 
 ## 0.2.1
 


### PR DESCRIPTION
On iOS 10 we had a crash when `UIProgressView` was added to incorrect view controller. 

<img width="1153" alt="Screenshot 2020-07-10 at 17 38 03" src="https://user-images.githubusercontent.com/3148214/87172175-1dfa0000-c2d4-11ea-91a7-e4f711b19bda.png">

Also on iOS 10 the list of photos was covered by navigation bar. I went for the solution of making it non-translucent 😞 as other solutions made worse result
- using `automaticallyAdjustsScrollViewInsets == true` did nothing
- using `edgesForExtendedLayout = [.left, .bottom, .right]` created an ugly animation when pushing the controller (considering navBar background)

If you can come up with other simple solution, let's bring it on. Otherwise I think that the UI is not that important.

![Simulator Screen Shot - iPhone 5s - 2020-07-10 at 17 27 15](https://user-images.githubusercontent.com/3148214/87172417-80530080-c2d4-11ea-82bb-914f0f8419ce.png)

#### Checklist
- [] Added tests (if applicable)
