### PR TITLE
Fix ACKImagePicker navigationBar opacity for iOS 13.0+

### DIFF
--- a/ACKImagePicker/ViewControllers/ACKCollectionViewController.swift
+++ b/ACKImagePicker/ViewControllers/ACKCollectionViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Photos
 
-protocol ACKImagePickerDelegate: class {
+protocol ACKImagePickerDelegate: AnyObject {
     var maximumNumberOfSelectedImages: Int? { get }
 
     func didSelectPhotos(_ photos: OrderedSet<PHAsset>)

--- a/ACKImagePicker/ViewControllers/ACKImagePicker.swift
+++ b/ACKImagePicker/ViewControllers/ACKImagePicker.swift
@@ -45,6 +45,15 @@ open class ACKImagePicker: UINavigationController {
         } else {
             navigationBar.isTranslucent = false
         }
+        
+        // on iOS 13.0+ opaque background needs to be set
+        // using `UINavigationBarAppearance`
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            navigationBar.standardAppearance = appearance
+            navigationBar.scrollEdgeAppearance = appearance
+        }
 
         self.rootController = rootController
     }

--- a/ACKImagePicker/ViewControllers/ACKImagePicker.swift
+++ b/ACKImagePicker/ViewControllers/ACKImagePicker.swift
@@ -45,7 +45,7 @@ open class ACKImagePicker: UINavigationController {
         } else {
             navigationBar.isTranslucent = false
         }
-        
+
         // on iOS 13.0+ opaque background needs to be set
         // using `UINavigationBarAppearance`
         if #available(iOS 13.0, *) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## Next 
+## Next
+
+## 0.3.3
+### Fixed
+
+- Fix `ACKImagePicker` navigationBar opacity for iOS 13.0+ ([#20](https://github.com/AckeeCZ/ACKImagePicker/pull/20)) by @IgorRosocha
 
 ## 0.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Next
 
-## 0.3.3
 ### Fixed
 
 - Fix `ACKImagePicker` navigationBar opacity for iOS 13.0+ ([#20](https://github.com/AckeeCZ/ACKImagePicker/pull/20)) by @IgorRosocha


### PR DESCRIPTION
On iOS `13.0+` opaque background of `ACKImagePicker` needs to be set using `UINavigationBarAppearance`.