### PR TITLE
Preserve selection order

### DIFF
--- a/ACKImagePicker/OrderedSet.swift
+++ b/ACKImagePicker/OrderedSet.swift
@@ -13,7 +13,7 @@ struct OrderedSet<Element>: CustomStringConvertible {
     private var iterator = 0
 
     var count: Int { storage.count }
-    
+
     var description: String {
         "OrderedSet [" + storage.map { String(describing: $0) }.joined(separator: ", ") + "]"
     }
@@ -32,7 +32,7 @@ struct OrderedSet<Element>: CustomStringConvertible {
 extension OrderedSet: Sequence, IteratorProtocol {
     mutating func next() -> Element? {
         guard iterator < count else { return nil }
-        
+
         defer { iterator += 1 }
         return storage[iterator] as? Element
     }

--- a/ACKImagePicker/OrderedSet.swift
+++ b/ACKImagePicker/OrderedSet.swift
@@ -8,23 +8,32 @@
 
 import Foundation
 
-final class OrderedSet<Item> {
+struct OrderedSet<Element>: CustomStringConvertible {
     private let storage = NSMutableOrderedSet()
+    private var iterator = 0
 
     var count: Int { storage.count }
+    
+    var description: String {
+        "OrderedSet [" + storage.map { String(describing: $0) }.joined(separator: ", ") + "]"
+    }
 
-    func add(_ object: Item) {
+    mutating func add(_ object: Element) {
         storage.add(object)
     }
 
-    func remove(_ object: Item) {
+    mutating func remove(_ object: Element) {
         let index = storage.index(of: object)
         guard index != NSNotFound else { return }
         storage.removeObject(at: index)
     }
+}
 
-    func forEach(_ body: (Item) -> Void) {
-        // swiftlint:disable:next force_cast
-        storage.forEach { body($0 as! Item) }
+extension OrderedSet: Sequence, IteratorProtocol {
+    mutating func next() -> Element? {
+        guard iterator < count else { return nil }
+        
+        defer { iterator += 1 }
+        return storage[iterator] as? Element
     }
 }

--- a/ACKImagePicker/ViewControllers/ImagePickerViewController.swift
+++ b/ACKImagePicker/ViewControllers/ImagePickerViewController.swift
@@ -389,7 +389,7 @@ extension ImagePickerViewController: ACKImagePickerDelegate {
         // call `onImagesPicked` block on main thread when whole group is finished
         group.notify(queue: .global(qos: .background)) { [weak self] in
             let images = photos.map(\.localIdentifier).compactMap { images[$0] }
-            
+
             // Show the completed progress for a brief moment, it's nicer than immediate dismiss
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
                 progressView.dismiss(animated: false)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix `ACKImagePicker` navigationBar opacity for iOS 13.0+ ([#20](https://github.com/AckeeCZ/ACKImagePicker/pull/20)) by @IgorRosocha
+- Preserve order of selected assets [#24](https://github.com/AckeeCZ/ACKImagePicker/pull/24)) by @olejnjak
 
 ## 0.3.2
 


### PR DESCRIPTION
Currently `onImagesPicked` callback doesn't respect user's order of selection, it is pretty much random (in my tests it seemed reversed). Now as we save fetched images in dictionary based on asset local identifiers, we can preserve order in which users selected it.